### PR TITLE
fix: thumbnails in dashboard wrap on small screen

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -2,7 +2,6 @@
 <div>
   <h1>{{ greeting }}</h1>
   <div class="dashboard">
-    <div class="spacer"></div>
     <div v-for="(deck, index) in collections" :key="index">
       <router-link :to="{ name: 'collection', params: { id: index } }">
         <div class="deck">
@@ -17,7 +16,6 @@
         </div>
       </router-link>
     </div>
-    <div class="spacer"></div>
   </div>
 </div>
 </template>
@@ -55,9 +53,4 @@ export default {
     4px 10px 0px rgb(180, 180, 180),
     12px 15px 10px rgba(0, 0, 0, 0.2);
 }
-/*
-.spacer {
-  width: 33%;
-  margin: 0 auto;
-}*/
 </style>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -37,9 +37,11 @@ export default {
 <style scoped>
 .dashboard {
   width: 80%;
-  height: 400px;
+  min-height: 400px;
   margin: 0 auto;
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .deck {
@@ -53,9 +55,9 @@ export default {
     4px 10px 0px rgb(180, 180, 180),
     12px 15px 10px rgba(0, 0, 0, 0.2);
 }
-
+/*
 .spacer {
   width: 33%;
   margin: 0 auto;
-}
+}*/
 </style>


### PR DESCRIPTION
I made thumbnails in dashboard wrap when you shrink the page and as far as I tested it works. However, in order to do this I had to make `spacer` invisible (I commented out it's styles). I am not sure what for was that `spacer`.