### PR TITLE
fix: prevent text select on cards

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -4,11 +4,8 @@
   @click="flip"
 >
   <div class="content">
-    <div>
-      {{ cardSide }}
-    </div>
+    {{ cardSide }}
   </div>
-  <div class="overlay"></div>
 </div>
 </template>
 
@@ -42,28 +39,26 @@ export default {
 
 <style scoped>
 .flashcard {
+  display: flex;
   margin: 15px;
   width: 200px;
   height: 200px;
-  position: relative;
   border-width: 3px;
   border-style: solid;
   border-radius: 20px;
 
-  -webkit-user-select: none; /* Chrome/Safari */        
+  -webkit-user-select: none; /* Chrome/Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+ */
   -o-user-select: none;
-  user-select: none;  
+  user-select: none;
 }
 
 .flashcard .content {
-  display: table;
-}
-
-.flashcard .content > div {
-  display: table-cell;
-  vertical-align: middle;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .question {
@@ -75,18 +70,6 @@ export default {
 .answer {
   border-color: #aaa;
   font-size: 1.4rem;
-}
-
-.flashcard > * {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.flashcard .overlay {
-  z-index: 10;
 }
 
 .pointer {

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -49,6 +49,12 @@ export default {
   border-width: 3px;
   border-style: solid;
   border-radius: 20px;
+
+  -webkit-user-select: none; /* Chrome/Safari */        
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
+  -o-user-select: none;
+  user-select: none;  
 }
 
 .flashcard .content {


### PR DESCRIPTION
I did a little research about this problem https://github.com/chingu-voyage4/Bears-Team-15/issues/64 and it seems this happens because text on the page is selected on double click. [Here on stackoverflow ](https://stackoverflow.com/questions/7018324/how-to-stop-highlighting-of-a-div-element-when-double-clicking) they suggest a decision and it kind of works. However, it prevents selecting the text overall (not just on double click, but on mouse selection also). I think, the text on cards probably shouldn't be selectable anyways, so I added the code for cards.