### PR TITLE
fix: can add when all cards are deleted

### DIFF
--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -49,7 +49,9 @@ export default {
   },
   beforeRouteLeave (to, from, next) {
     if (this.readyToSave) {
-      this.removeLastEmpty()
+      if(this.lastCard){
+        this.removeLastEmpty()
+      }      
       next()
     }
   },
@@ -94,7 +96,9 @@ export default {
     },
     add () {
       if (this.readyToSave ) {
-        if (this.lastCardIsNotFilled === 'both') {
+        if(!this.lastCard){
+          this.collection.items.push({...this.emptyCard})
+        } else if (this.lastCardIsNotFilled === 'both') {
           this.blur(this.lastIndex, 'q')
           this.blur(this.lastIndex, 'a')
         } else if (this.lastCardIsNotFilled) {


### PR DESCRIPTION
It seems this (https://github.com/chingu-voyage4/Bears-Team-15/issues/73) was happening because on `add` it was trying to verify if last card is not empty and getting `lastCard is undefined`.