### PR TITLE
fix: Put `/collection/new` before `/collection/:id` paths in router

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,11 @@ export default new Router({
           component: Dashboard
         },
         {
+          path: '/collection/new',
+          name: 'collectionNew',
+          component: CollectionNew
+        },
+        {
           path: '/collection/:id',
           component: Collection,
           props: true,
@@ -45,11 +50,6 @@ export default new Router({
               props: true,
             },
           ]
-        },
-        {
-          path: '/collection/new',
-          name: 'collectionNew',
-          component: CollectionNew
         },
       ]
     }


### PR DESCRIPTION
So now when user refreshes the `collectionNew` view it doesn't crash

Closes #75