### PR TITLE
Fix remove duplicates#81

### DIFF
--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -1,14 +1,19 @@
 <template>
 <div class="container">
   <div>
-    <input
-      v-model="collection.collectionName"
-      type="text" placeholder="Collection name"
-      :class="titleClass">
     <button
       v-if="!createMode"
       @click="deleteCollection"
     >Delete Collection</button>
+    <button
+      @click="removeDuplicates"
+    >Remove Duplicates</button>
+  </div>
+  <div>
+    <input
+      v-model="collection.collectionName"
+      type="text" placeholder="Collection name"
+      :class="titleClass">    
     <router-link
       v-if="createMode"
       :to="homeRoute"
@@ -109,6 +114,9 @@ export default {
     deleteCollection () {
       this.$store.dispatch('deleteCollection', this.id)
       this.$router.push(this.homeRoute)
+    },
+    removeDuplicates () {
+      this.$store.dispatch('removeDuplicates', this.id)
     },
     remove (index) {
       const id = this.id

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -1,11 +1,11 @@
 <template>
 <div class="container">
   <div>
-    <button
+    <button class="btn btn-delete"
       v-if="!createMode"
       @click="deleteCollection"
     >Delete Collection</button>
-    <button
+    <button class="btn btn-delete"
       @click="removeDuplicates"
     >Remove Duplicates</button>
   </div>
@@ -181,6 +181,9 @@ export default {
   border-radius: 1em/50%;
 }
 
+.btn-delete{
+  background-color: #ff4d4d;
+}
 
 .btn-add {
   background-color: #7db85e;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -92,10 +92,24 @@ export default new Vuex.Store({
         this.replaceState(Object.assign(state, JSON.parse(loc)))
       }
     },
+    removeDuplicates (state, id){
+      let deck = state.collections[id].items
+      let arrQ = deck.map((item) => item.q)
+      let setQ = new Set(arrQ)
+      if(setQ.length == arrQ.length){return}
+      let newDeck = []
+      setQ.forEach(function(q){
+        newDeck.push(deck[arrQ.indexOf(q)])
+      })
+      state.collections[id].items = newDeck
+    }
   },
   actions: {
     deleteCollection (context, id) {
       context.commit('deleteCollection', id)
+    },
+    removeDuplicates (context, id) {
+      context.commit('removeDuplicates', id)
     }
   }
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -93,9 +93,9 @@ export default new Vuex.Store({
       }
     },
     removeDuplicates (state, id){
-      let deck = state.collections[id].items
-      let arrQ = deck.map((item) => item.q)
-      let setQ = new Set(arrQ)
+      const deck = state.collections[id].items
+      const arrQ = deck.map((item) => item.q)
+      const setQ = new Set(arrQ)
       if(setQ.length == arrQ.length){return}
       let newDeck = []
       setQ.forEach(function(q){


### PR DESCRIPTION
It is made to remove cards with duplicate questions and as far as I tested it works. Removing duplicates can be implemented in many ways and I'm not sure if this is most performant, but I wanted to avoid multiple for loops.

resolves #81 