### PR TITLE
Hotfix local storage

### DIFF
--- a/src/components/DashboardPrivate.vue
+++ b/src/components/DashboardPrivate.vue
@@ -24,8 +24,5 @@ import { mapState } from 'vuex'
 export default {
   name: "DashboardPrivate",
   computed: mapState(['collections']),
-  beforeCreate () {
-    this.$store.dispatch('fetchLocalCollections')
-  },
 }
 </script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -14,12 +14,12 @@
 
 <script>
 export default {
-  data: () => ({
-    version: '0.4'
-  }),
   computed: {
     currentYear () {
       return (new Date()).getFullYear()
+    },
+    version () {
+      return this.$store.state.appVersion
     }
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -81,7 +81,6 @@ export default new Vuex.Store({
         const parsed = JSON.parse(loc)
         const ver = parsed.appVersion
         if (ver && ver >= state.appVersion) {
-          console.log(ver)
           commit('readCollections', parsed)
         }
       }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,6 +6,7 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
+    appVersion: '0.4',
     collections: [],
     publicCollections: [],
     counter: 1,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -74,11 +74,16 @@ export default new Vuex.Store({
     },
   },
   actions: {
-    fetchLocalCollections ({ commit }) {
+    fetchLocalCollections ({ commit, state }) {
       commit('setLoadingMode', true)
       const loc = localStorage.getItem('store')
       if (loc) {
-        commit('readCollections', JSON.parse(loc))
+        const parsed = JSON.parse(loc)
+        const ver = parsed.appVersion
+        if (ver && ver >= state.appVersion) {
+          console.log(ver)
+          commit('readCollections', parsed)
+        }
       }
       commit('setLoadingMode', false)
     },


### PR DESCRIPTION
Don't load local data if it's of older app version.

Maybe in the future we should write some function to convert old version of stored data to new... Or maybe we wouldn't have to bother, because we will use DB instead