### PR TITLE
feat: Auth API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1350,6 +1350,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "bfj-node4": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/chingu-voyage4/Bears-Team-15/#readme",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "mongoose": "^5.0.6"

--- a/server/errMessages.js
+++ b/server/errMessages.js
@@ -1,0 +1,15 @@
+export default {
+  registration: {
+    common: 'Failed to register user',
+    duplicate: 'User is already registered',
+    empty: {
+      login: 'Failed to register. Login must be provided',
+      password: 'Failed to register. Password must be provided',
+    }
+  },
+  login: {
+    common: 'Login error. Access denied',
+    wrongCredentials: 'Wrong credentials. Access denied',
+  },
+  worstScenario: 'Server error'
+}

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose')
+import bcrypt from 'bcryptjs'
+
 
 const CollectionSchema = new mongoose.Schema({
   collectionName: {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,6 +1,52 @@
 const mongoose = require('mongoose')
 import bcrypt from 'bcryptjs'
 
+const UserSchema = new mongoose.Schema({
+  login: {
+    type: String,
+    required: true,
+    minLength: 1,
+    unique: true,
+  },
+  password: {
+    type: String,
+    required: true,
+    minLength: 1,
+  },
+})
+
+UserSchema.methods.toJSON = function () {
+  const { login, _id } = this
+  return { login, _id }
+}
+
+UserSchema.pre('save', function (next) {
+  const user = this
+
+  if (user.isModified('password')) {
+    const salt = bcrypt.genSaltSync(10)
+    const hash = bcrypt.hashSync(user.password, salt)
+    user.password = hash
+  }
+
+  next()
+})
+
+UserSchema.statics.findByCredentials = function (login, password) {
+  const User = this
+  return User.findOne({ login })
+    .then(user => {
+      if (!user) {
+        return Promise.reject('wrong')
+      }
+      return new Promise((resolve, reject) => {
+        bcrypt.compare(password, user.password)
+          .then (res => {
+            res ? resolve(user) : reject('wrong')
+          })
+      })
+    })
+}
 
 const CollectionSchema = new mongoose.Schema({
   collectionName: {
@@ -32,6 +78,7 @@ const CardSchema = new mongoose.Schema({
 })
 
 module.exports = {
+  User: mongoose.model('User', UserSchema),
   Collection: mongoose.model('Collection', CollectionSchema),
   Card: mongoose.model('Card', CardSchema),
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,8 @@
 const express = require('express')
 const router = express.Router()
 
+import errors from '../errMessages'
+
 router.get('/', (req, res) => {
   res.status(200).sendFile(path.resolve(__dirname, '../../index.html'))
 })

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,7 +7,7 @@ router.get('/', (req, res) => {
   res.status(200).sendFile(path.resolve(__dirname, '../../index.html'))
 })
 
-const { Collection, Card } = require('../models')
+const { User, Collection, Card } = require('../models')
 
 router.get('/collection', (req, res) => {
   res.status(200).send('Collection API route')

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,6 +9,54 @@ router.get('/', (req, res) => {
 
 const { User, Collection, Card } = require('../models')
 
+router.post('/register', (req, res) => {
+  const { login, password } = req.body
+  User.create({ login, password })
+    .then(user => {
+      res.status(200).send(user)
+    })
+    .catch(err => {
+      let statusCode = 400
+      let msg = errors.registration.common
+      if (err.code == 11000) {
+        msg = errors.registration.duplicate
+      } else if (err.errors) {
+        const e = err.errors
+        if (e.login && e.login.kind === 'required') {
+          msg = errors.registration.empty.login
+        } else if (e.password && e.password.kind === 'required') {
+          msg = errors.registration.empty.password
+        }
+      } else {
+        console.error(err)
+        statusCode = 500
+      }
+      res.status(statusCode).send(msg)
+    })
+})
+
+router.post('/login', async (req, res) => {
+  const { login, password } = req.body
+  let msg = ''
+  let statusCode = 403
+  try {
+    if (!login || !password) throw 'empty'
+    const user = await User.findByCredentials(login, password)
+    res.status(200).send(user)
+  } catch (err) {
+    if (err === 'empty') {
+      msg = errors.login.common
+    } else if (err === 'wrong') {
+      msg = errors.login.wrongCredentials
+    } else {
+      console.error(err)
+      msg = errors.worstScenario
+      statusCode = 500
+    }
+    res.status(statusCode).send(msg)
+  }
+})
+
 router.get('/collection', (req, res) => {
   res.status(200).send('Collection API route')
 })

--- a/server/seed/modules.js
+++ b/server/seed/modules.js
@@ -4,6 +4,7 @@ const { Collection, Card } = require('../models')
 const resetAllCollections = async () => {
   try {
     await Collection.remove({})
+    await Card.remove({})
     return Promise.resolve()
   } catch (err) {
     console.error(err)

--- a/server/seed/modules.js
+++ b/server/seed/modules.js
@@ -1,8 +1,9 @@
 const collections = require('./collections')
-const { Collection, Card } = require('../models')
+const { User, Collection, Card } = require('../models')
 
 const resetAllCollections = async () => {
   try {
+    await User.remove({})
     await Collection.remove({})
     await Card.remove({})
     return Promise.resolve()

--- a/test/authentication.test.js
+++ b/test/authentication.test.js
@@ -1,0 +1,169 @@
+import { app, server } from '../server/app'
+import * as seed from '../server/seed/modules'
+import errors from '../server/errMessages'
+
+import chai from 'chai'
+import chaiHttp from 'chai-http'
+import { ObjectId } from 'mongodb'
+
+chai.use(chaiHttp)
+
+const quaker = {
+  login: 'johndoe',
+  password: 'password',
+}
+
+beforeAll(async () => {
+  await seed.resetAllCollections()
+  await seed.populateCollections()
+  await chai.request(app).post('/register').send(quaker)
+})
+
+afterAll(server.close())
+
+describe('POST `/register`', () => {
+  const route = '/register'
+
+  const newUser = {
+    login: 'foobar',
+    password: 'password',
+  }
+
+  it('should save a user', () =>
+    chai.request(app)
+      .post(route)
+      .send(newUser)
+      .then(response => {
+        expect(response).toHaveProperty('status', 200)
+        const received = response.body
+        expect(received).toHaveProperty('_id')
+        expect(received).toHaveProperty('login', newUser.login)
+        expect(received).not.toHaveProperty('password')
+      })
+  )
+
+  const doppelganger = {
+    login: quaker.login,
+    password: 'doesntmatter',
+  }
+
+  it('should not create duplicate `login`', done =>
+    chai.request(app)
+      .post(route)
+      .send(doppelganger)
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 400)
+        expect(res).toHaveProperty('text', errors.registration.duplicate)
+        done()
+      })
+  )
+
+  it('should not register user without login', done =>
+    chai.request(app)
+      .post(route)
+      .send({ login: '', password: 'onlyPassword' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 400)
+        expect(res).toHaveProperty('text', errors.registration.empty.login)
+        done()
+      })
+  )
+
+  it('should not register user without password', done =>
+    chai.request(app)
+      .post(route)
+      .send({ login: 'anylogin', password: '' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 400)
+        expect(res).toHaveProperty('text', errors.registration.empty.password)
+        done()
+      })
+  )
+
+  xit('should not register user with invalid login')
+
+  xit('should not register user with invalid password')
+
+  it('should register another user with same password', () =>
+    chai.request(app)
+      .post(route)
+      .send({ login: 'goo', password: quaker.password})
+      .then(res => {
+        const received = res.body
+        expect(received).toHaveProperty('_id')
+        expect(received).toHaveProperty('login', 'goo')
+      })
+  )
+})
+
+describe('POST `/login`', () => {
+  const route = '/login'
+
+  it('should login by credentials', () =>
+    chai.request(app)
+      .post(route)
+      .send(quaker)
+      .then(response => {
+        expect(response).toHaveProperty('status', 200)
+        const received = response.body
+        expect(received).toHaveProperty('_id')
+        expect(received).toHaveProperty('login', quaker.login)
+        expect(received).not.toHaveProperty('password')
+      })
+  )
+
+  it('should respond 403 to empty request', done =>
+    chai.request(app)
+      .post(route)
+      .send({})
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 403)
+        expect(res).toHaveProperty('text', errors.login.common)
+        done()
+      })
+  )
+
+  it('should respond 403 to empty login', done =>
+    chai.request(app)
+      .post(route)
+      .send({ password: 'anything' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 403)
+        expect(res).toHaveProperty('text', errors.login.common)
+        done()
+      })
+  )
+
+  it('should respond 403 to empty password', done =>
+    chai.request(app)
+      .post(route)
+      .send({ login: 'any' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 403)
+        expect(res).toHaveProperty('text', errors.login.common)
+        done()
+      })
+  )
+
+  it('should not login if wrong `login`', done =>
+    chai.request(app)
+      .post(route)
+      .send({ login: 'wronglogin', password: 'anypassword' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 403)
+        expect(res).toHaveProperty('text', errors.login.wrongCredentials)
+        done()
+      })
+  )
+
+  it('should not login if wrong `password`', done =>
+    chai.request(app)
+      .post(route)
+      .send({ login: quaker.login, password: 'wrongpassword' })
+      .end((err, res) => {
+        expect(res).toHaveProperty('status', 403)
+        expect(res).toHaveProperty('text', errors.login.wrongCredentials)
+        done()
+      })
+  )
+})

--- a/test/authentication.test.js
+++ b/test/authentication.test.js
@@ -47,36 +47,36 @@ describe('POST `/register`', () => {
     password: 'doesntmatter',
   }
 
-  it('should not create duplicate `login`', done =>
+  it('should not create duplicate `login`', () =>
     chai.request(app)
       .post(route)
       .send(doppelganger)
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 400)
         expect(res).toHaveProperty('text', errors.registration.duplicate)
-        done()
       })
   )
 
-  it('should not register user without login', done =>
+  it('should not register user without login', () =>
     chai.request(app)
       .post(route)
       .send({ login: '', password: 'onlyPassword' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 400)
         expect(res).toHaveProperty('text', errors.registration.empty.login)
-        done()
       })
   )
 
-  it('should not register user without password', done =>
+  it('should not register user without password', () =>
     chai.request(app)
       .post(route)
       .send({ login: 'anylogin', password: '' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 400)
         expect(res).toHaveProperty('text', errors.registration.empty.password)
-        done()
       })
   )
 
@@ -112,58 +112,58 @@ describe('POST `/login`', () => {
       })
   )
 
-  it('should respond 403 to empty request', done =>
+  it('should respond 403 to empty request', () =>
     chai.request(app)
       .post(route)
       .send({})
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 403)
         expect(res).toHaveProperty('text', errors.login.common)
-        done()
       })
   )
 
-  it('should respond 403 to empty login', done =>
+  it('should respond 403 to empty login', () =>
     chai.request(app)
       .post(route)
       .send({ password: 'anything' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 403)
         expect(res).toHaveProperty('text', errors.login.common)
-        done()
       })
   )
 
-  it('should respond 403 to empty password', done =>
+  it('should respond 403 to empty password', () =>
     chai.request(app)
       .post(route)
       .send({ login: 'any' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 403)
         expect(res).toHaveProperty('text', errors.login.common)
-        done()
       })
   )
 
-  it('should not login if wrong `login`', done =>
+  it('should not login if wrong `login`', () =>
     chai.request(app)
       .post(route)
       .send({ login: 'wronglogin', password: 'anypassword' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 403)
         expect(res).toHaveProperty('text', errors.login.wrongCredentials)
-        done()
       })
   )
 
-  it('should not login if wrong `password`', done =>
+  it('should not login if wrong `password`', () =>
     chai.request(app)
       .post(route)
       .send({ login: quaker.login, password: 'wrongpassword' })
-      .end((err, res) => {
+      .catch(err => {
+        const res = err.response
         expect(res).toHaveProperty('status', 403)
         expect(res).toHaveProperty('text', errors.login.wrongCredentials)
-        done()
       })
   )
 })


### PR DESCRIPTION
`/register` and `/login`

Both routes take { login, password } as input.

Both routes respond with { login, _id } (this is defined in user's
`toJSON` method)

Every response in case of error is defined in
`test/authentication.test.js`