### PR TITLE
Improve editing#67

### DIFF
--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -37,6 +37,8 @@
   </div>
 	<app-card-input
     v-for="(card, index) in collection.items" :key="index"
+		@addError="addError"
+		@removeError="removeError"
 	></app-card-input>
   <button
     class="btn btn-add newCard"
@@ -61,8 +63,9 @@ export default {
   data: () => ({
     homeRoute: { name: 'home' },
     emptyCard: { q: '', a: '' },
-    errors: { q: [], a: [] },
-    focused: { qa: '', index: null }
+		errorCount: 0,
+		titleError: false,
+    focusedTitle: false,
   }),
   beforeRouteLeave (to, from, next) {
     if (this.collection) {
@@ -97,15 +100,10 @@ export default {
       return null
     },
     readyToSave () {
-      return this.errors.q.length === 0
-        && this.errors.a.length === 0
-        && !this.titleError
-    },
-    titleError () {
-      return this.collection.collectionName === ''
+			return this.errorCount === 0 && !this.titleError
     },
     titleClass () {
-      return { error:  this.titleError && this.focused.qa !== 'title' }
+      return { error:  this.titleError && !this.focusedTitle }
     }
   },
   methods: {
@@ -132,10 +130,7 @@ export default {
     remove (index) {
       const id = this.id
       this.$store.commit('removeCard', { id, index })
-      const helper = a => a.filter(x => x !== index)
-        .map(x => x > index ? x - 1 : x)
-      this.errors.q = helper(this.errors.q)
-      this.errors.a = helper(this.errors.a)
+			this.removeError(errCount)
     },
     add (cb) {
       if (this.checkLastCard()) {
@@ -158,6 +153,13 @@ export default {
     focus (index, qa) {
       this.focused = { index, qa }
     },
+		addError() {
+			this.errorCount += 1
+		},
+		removeError(count) {
+			this.errorCount -= count ? count : 1
+			this.errorCount = Math.max(this.errorCount, 0)
+		},
 
 	  fork(){
 	    this.$store.dispatch('fork', this.collection)

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -43,8 +43,14 @@
   </div>
 	<app-card-input
     v-for="(card, index) in collection.items" :key="index"
+		ref="card"
+		:card="card"
+		:index="index"
+		@change="x => change(x)"
+		@remove="count => remove(index, count)"
 		@addError="addError"
 		@removeError="removeError"
+		@focusNext="index => focusNext(index)"
 	></app-card-input>
   <button
     class="btn btn-add newCard"

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -85,6 +85,9 @@ export default {
       next()
     }
   },
+	created () {
+		if (this.createMode) this.add()
+	},
   computed: {
     collection () {
       return this.$store.getters.collection(this.id)

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -82,11 +82,7 @@ export default {
     focusedTitle: false,
 		toSend: {
 			collectionName: '',
-			items: {
-			  add: [],
-				del: [],
-				mod: [],
-			}
+			items: { add: [], del: [], mod: [] }
 		},
   }),
   beforeRouteLeave (to, from, next) {

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -117,6 +117,13 @@ export default {
 	    this.$store.dispatch('fork', this.collection)
 	    this.$router.push(this.homeRoute)
 	  },
+		changeTitle (title) {
+			if (title === this.collection.collectionName) {
+				delete this.toSend.collectionName
+			} else {
+				this.toSend.collectionName = title
+			}
+		},
 		change ({ index, qa, body }) {
 			const card = this.collection.items[index]
 			if (card._id) {

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -197,7 +197,9 @@ export default {
 				  )
 				})
 			}
-			else this.$refs.card[index +1].$refs.pq[0].click()
+			else if (this.$refs.card[index+1].$refs.pq)
+				this.$refs.card[index+1].$refs.pq[0].click()
+			else this.$refs.card[index+1].$refs.q[0].focus()
     },
   }
 }

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -232,5 +232,21 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
+.error {
+  border: 1px solid red;
+}
+.qa {
+	display: inline-block;
+	width: 150px;
+	height: 2em;
+}
+.qa p {
+	text-align: left;
+}
+.qa * {
+	margin: 0;
+	width: inherit;
+	height: inherit;
+}
 </style>

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -123,6 +123,18 @@ export default {
     removeDuplicates () {
       this.$store.dispatch('removeDuplicates', this.id)
     },
+    save () {
+        if (this.createMode) {
+          this.$emit('save')
+        } else {
+          this.$store.dispatch('saveState')
+        }
+        this.$router.push(this.homeRoute)
+    },
+	  fork(){
+	    this.$store.dispatch('fork', this.collection)
+	    this.$router.push(this.homeRoute)
+	  },
 		change ({ index, qa, body }) {
 			const card = this.collection.items[index]
 			if (card._id) {
@@ -176,14 +188,6 @@ export default {
 
         if (typeof cb === 'function') cb()
     },
-    save () {
-        if (this.createMode) {
-          this.$emit('save')
-        } else {
-          this.$store.dispatch('saveState')
-        }
-        this.$router.push(this.homeRoute)
-    },
 		inputTitle () {
 			this.inputMode = true
 			this.inputValue = this.displayedTitle
@@ -224,10 +228,6 @@ export default {
 			}
 			else this.$refs.card[index +1].$refs.pq[0].click()
     },
-	  fork(){
-	    this.$store.dispatch('fork', this.collection)
-	    this.$router.push(this.homeRoute)
-	  },
   }
 }
 </script>

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -227,7 +227,7 @@ export default {
 	  fork(){
 	    this.$store.dispatch('fork', this.collection)
 	    this.$router.push(this.homeRoute)
-	  }
+	  },
   }
 }
 </script>

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -78,7 +78,7 @@ export default {
   }),
   beforeRouteLeave (to, from, next) {
     if (this.collection) {
-      if (this.readyToSave) {
+			if (this.errorCount === 0) {
         next()
       }
     } else {
@@ -89,18 +89,12 @@ export default {
     collection () {
       return this.$store.getters.collection(this.id)
     },
-		receivedTitle () {
-			return this.collection.collectionName
-		},
-		displayedTitle () {
+		title () {
 			const changed = this.toSend.collectionName
-			return changed ? changed : this.receivedTitle
+			return changed ? changed : this.collection.collectionName
 		},
     lastIndex () {
       return this.collection.items.length - 1;
-    },
-    readyToSave () {
-			return this.errorCount === 0 && !this.titleError
     },
   },
   methods: {

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -112,7 +112,7 @@ export default {
         if (this.createMode) {
           this.$emit('save')
         } else {
-          this.$store.dispatch('saveState')
+          this.$store.dispatch('updateCollection', toSend)
         }
         this.$router.push(this.homeRoute)
     },

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -102,11 +102,8 @@ export default {
 			return this.collection.collectionName
 		},
 		displayedTitle () {
-			if (this.toSend.collectionName) {
-				return this.toSend.collectionName
-			} else {
-				return this.receivedTitle
-			}
+			const changed = this.toSend.collectionName
+			return changed ? changed : this.receivedTitle
 		},
     lastIndex () {
       return this.collection.items.length - 1;

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -207,6 +207,9 @@ export default {
 .error {
   border: 1px solid red;
 }
+.editable {
+	cursor: text;
+}
 .qa {
 	display: inline-block;
 	width: 150px;

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -195,7 +195,19 @@ export default {
 			this.errorCount -= count ? count : 1
 			this.errorCount = Math.max(this.errorCount, 0)
 		},
+    focusNext (index) {
+			if (index == -1) this.blurTitle()
 
+			const nextCard = this.collection.items[index+1]
+			if (!nextCard) {
+				this.add(() => {
+					this.$nextTick(() =>
+					  this.$refs.card[index+1].$refs.q[0].focus()
+				  )
+				})
+			}
+			else this.$refs.card[index +1].$refs.pq[0].click()
+    },
 	  fork(){
 	    this.$store.dispatch('fork', this.collection)
 	    this.$router.push(this.homeRoute)

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -88,9 +88,6 @@ export default {
   beforeRouteLeave (to, from, next) {
     if (this.collection) {
       if (this.readyToSave) {
-        if (this.lastCardIsNotFilled === 'both') {
-          this.remove(this.lastIndex, 1)
-        }
         next()
       }
     } else {
@@ -114,19 +111,6 @@ export default {
     lastIndex () {
       return this.collection.items.length - 1;
     },
-    lastCardIsNotFilled () {
-      if (this.lastIndex === -1) return null
-      const lastCard = this.collection.items[this.lastIndex]
-      if (lastCard.q === '') {
-        if (lastCard.a === '') {
-          return 'both'
-        }
-        return 'q'
-      } else if (lastCard.a === ''){
-        return 'a'
-      }
-      return null
-    },
     readyToSave () {
 			return this.errorCount === 0 && !this.titleError
     },
@@ -135,19 +119,6 @@ export default {
     }
   },
   methods: {
-    checkLastCard () {
-      if (this.readyToSave ) {
-        if (this.lastCardIsNotFilled === 'both') {
-          this.blur(this.lastIndex, 'q')
-          this.blur(this.lastIndex, 'a')
-        } else if (this.lastCardIsNotFilled) {
-          this.blur(this.lastIndex, this.lastCardIsNotFilled)
-        } else {
-          return true
-        }
-      }
-      return false
-    },
     deleteCollection () {
       this.$store.dispatch('deleteCollection', this.id)
       this.$router.push(this.homeRoute)
@@ -197,7 +168,6 @@ export default {
 			this.removeError(errCount)
     },
     add (cb) {
-      if (this.checkLastCard()) {
         const card = { ...this.emptyCard }
         const id = this.id
         this.$store.commit('addCard', { id, card })
@@ -208,17 +178,14 @@ export default {
 				this.toSend.items.add.push(lastCard)
 
         if (typeof cb === 'function') cb()
-      }
     },
     save () {
-      if (this.checkLastCard()) {
         if (this.createMode) {
           this.$emit('save')
         } else {
           this.$store.dispatch('saveState')
         }
         this.$router.push(this.homeRoute)
-      }
     },
 		inputTitle () {
 			this.inputMode = true

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -20,14 +20,20 @@
   </div>
   <div>
     <input
-      v-model.trim="collection.collectionName"
+		  v-if="inputMode"
+      v-model.trim="inputValue"
+			ref="title"
       type="text" placeholder="Collection name"
       :class="titleClass"
       :autofocus="createMode"
-      @focus="focus(null, 'title')"
-      @blur="onBlur(null, 'title')"
-      @keyup.enter="focusNext($event.target, 'title')"
+      @focus="focusTitle"
+      @blur="blurTitle"
+      @keyup.enter="focusNext(-1)"
     >
+		<p
+			v-else
+			@click="inputTitle"
+		>{{ displayedTitle }}</p>
     <router-link
       v-if="createMode"
       :to="homeRoute"
@@ -65,6 +71,8 @@ export default {
     emptyCard: { q: '', a: '' },
 		errorCount: 0,
 		titleError: false,
+		inputMode: false,
+		inputValue: '',
     focusedTitle: false,
   }),
   beforeRouteLeave (to, from, next) {
@@ -83,6 +91,16 @@ export default {
     collection () {
       return this.$store.getters.collection(this.id)
     },
+		receivedTitle () {
+			return this.collection.collectionName
+		},
+		displayedTitle () {
+			if (this.toSend.collectionName) {
+				return this.toSend.collectionName
+			} else {
+				return this.receivedTitle
+			}
+		},
     lastIndex () {
       return this.collection.items.length - 1;
     },
@@ -150,9 +168,26 @@ export default {
         this.$router.push(this.homeRoute)
       }
     },
-    focus (index, qa) {
-      this.focused = { index, qa }
+		inputTitle () {
+			this.inputMode = true
+			this.inputValue = this.displayedTitle
+      this.$nextTick(() => this.$refs.title.focus())
+		},
+    focusTitle (index, qa) {
+      this.focusedTitle = true
     },
+    blurTitle () {
+			if (this.inputValue !== '') {
+				this.inputMode = false
+				this.titleError = false
+				// direct mutation, change it:
+				this.collection.collectionName = this.inputValue
+				this.toSend.collectionName = this.inputValue
+			} else {
+				this.titleError = true
+			}
+      this.focusedTitle = false
+		},
 		addError() {
 			this.errorCount += 1
 		},

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -35,30 +35,9 @@
       <button>Discard</button>
     </router-link>
   </div>
-  <div
-    class="card"
+	<app-card-input
     v-for="(card, index) in collection.items" :key="index"
-  >
-    <input
-      type="text" v-model.trim="card.q" placeholder="Question"
-      @focus="focus(index, 'q')"
-      @blur="blur(index, 'q')"
-      ref="q"
-      :class="inputClass(index, 'q')"
-      @keyup.enter="focusNext($event.target, 'q', index)"
-    >
-    <input
-      type="text" v-model.trim="card.a" placeholder="Answer"
-      @focus="focus(index, 'a')"
-      @blur="blur(index, 'a')"
-      ref="a"
-      :class="inputClass(index, 'a')"
-      @keyup.enter="focusNext($event.target, 'a', index)"
-    >
-    <button
-      @click="remove(index)"
-    >X</button>
-  </div>
+	></app-card-input>
   <button
     class="btn btn-add newCard"
     @click="add"
@@ -72,8 +51,13 @@
 </template>
 
 <script>
+import CardInput from '@/components/CollectionEdit__Card'
+
 export default {
   props: ['id', 'createMode'],
+	components: {
+		appCardInput: CardInput,
+	},
   data: () => ({
     homeRoute: { name: 'home' },
     emptyCard: { q: '', a: '' },
@@ -174,57 +158,7 @@ export default {
     focus (index, qa) {
       this.focused = { index, qa }
     },
-    blur (index, qa) {
-      //check if there was an error before
-      const errorIndex = this.errors[qa]
-        .findIndex(x => x === index)
-      if (errorIndex !== -1) {
-        // if there was an error – remove it from error list
-        // if on blur value is not empty
-        if (this.collection.items[index][qa] !== ''){
-          this.errors[qa].splice(errorIndex, 1)
-        }
-      } else if (this.collection.items[index][qa] === ''){
-        // if there wasn't an error and now it is – push it
-        this.errors[qa].push(index)
-      }
 
-      this.onBlur(index, qa)
-    },
-    onBlur (index, qa) {
-      this.focused = { index: null, qa: ''}
-    },
-    focusNext (target, type, index) {
-      if (target.value.trim() !== '') {
-        const focus = (qa, i) => {
-          this.$nextTick(() => {
-            const column = this.$refs[qa]
-            if (column && column[i]) column[i].focus()
-            else if (qa !== 'a') {
-              this.add(() => this.focusNext(target, type, index))
-            }
-          })
-        }
-        switch (type) {
-          case 'title':
-            focus('q', 0)
-            break;
-          case 'q':
-            focus('a', index)
-            break;
-          case 'a':
-            focus('q', index + 1)
-            break;
-        }
-      }
-    },
-    inputClass (index, qa) {
-      const err = this.errors[qa]
-          .filter( x => x === index).length > 0 ? true : false
-      const focused = this.focused.qa === qa
-        && this.focused.index === index
-      return { error: err && !focused }
-    },
 	  fork(){
 	    this.$store.dispatch('fork', this.collection)
 	    this.$router.push(this.homeRoute)
@@ -234,7 +168,4 @@ export default {
 </script>
 
 <style scoped>
-.error {
-  border: 1px solid red;
-}
 </style>

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -156,7 +156,7 @@ export default {
 			} else {
 				const addList = this.toSend.items.add
 				addList.splice(card.index, 1)
-				addList.map(x => {
+				addList.forEach(x => {
 					if (x.index > card.index) x.index -= 1
 				})
 			}

--- a/src/components/CollectionEdit.vue
+++ b/src/components/CollectionEdit.vue
@@ -8,7 +8,7 @@
       >Fork</button>
 	</div>
 </div>
-<div v-if="!collection.shared">
+<div v-else>
   <div>
     <button class="btn btn-delete"
       v-if="!createMode"

--- a/src/components/CollectionEdit__Card.vue
+++ b/src/components/CollectionEdit__Card.vue
@@ -1,0 +1,82 @@
+<template>
+<div class="card">
+	<div class="qa"
+	  v-for="(qa, index) in ['q', 'a']" :key="index"
+	>
+	  <input
+			v-if="inputMode[qa]"
+	    type="text" v-model.trim="inputs[qa]" :placeholder="placeholders[qa]"
+      :ref="qa"
+			@focus="focus(qa)"
+			@blur="blur(qa)"
+	    :class="inputClass(qa)"
+	    @keyup.enter="focusNext(qa)"
+	  >
+		<p
+			class="ellipsis"
+	    :ref="'p'+qa"
+			v-else
+			@click="input(qa)"
+		>{{ received[qa] }}</p>
+	</div>
+  <button
+	  @click="remove"
+  >X</button>
+</div>
+</template>
+
+<script>
+export default {
+  props: [ 'index', 'card' ],
+  data: () => ({
+		placeholders: { q: 'Question', a: 'Answer' },
+		inputMode: { q: false, a: false },
+		focused: { q: false, a: false },
+		errors: { q: false, a: false },
+		inputs: { q: '', a: '' },
+  }),
+  created () {
+    if (this.card.q === '' && this.card.a === '') {
+      this.inputMode = { q: true, a: true }
+      this.input('q')
+    }
+  },
+	computed: {
+		received () {
+			const { q, a } = this.card
+			return { q, a }
+		},
+	},
+  methods: {
+		input (qa) {
+			this.inputMode[qa] = true
+			this.inputs = this.received
+      this.$nextTick(() => this.$refs[qa][0].focus())
+		},
+    inputClass (qa) {
+      const err = this.errors[qa]
+      const focused = this.focused[qa]
+      return { error: err && !focused }
+    },
+  }
+}
+</script>
+
+<style>
+.error {
+  border: 1px solid red;
+}
+.qa {
+	display: inline-block;
+	width: 150px;
+	height: 2em;
+}
+.qa p {
+	text-align: left;
+}
+.qa * {
+	margin: 0;
+	width: inherit;
+	height: inherit;
+}
+</style>

--- a/src/components/CollectionEdit__Card.vue
+++ b/src/components/CollectionEdit__Card.vue
@@ -102,21 +102,5 @@ export default {
 }
 </script>
 
-<style>
-.error {
-  border: 1px solid red;
-}
-.qa {
-	display: inline-block;
-	width: 150px;
-	height: 2em;
-}
-.qa p {
-	text-align: left;
-}
-.qa * {
-	margin: 0;
-	width: inherit;
-	height: inherit;
-}
+<style scoped>
 </style>

--- a/src/components/CollectionEdit__Card.vue
+++ b/src/components/CollectionEdit__Card.vue
@@ -13,7 +13,7 @@
 	    @keyup.enter="focusNext(qa)"
 	  >
 		<p
-			class="ellipsis"
+			class="ellipsis editable"
 	    :ref="'p'+qa"
 			v-else
 			@click="input(qa)"

--- a/src/components/CollectionEdit__Card.vue
+++ b/src/components/CollectionEdit__Card.vue
@@ -58,6 +58,16 @@ export default {
       const focused = this.focused[qa]
       return { error: err && !focused }
     },
+    remove () {
+      let count = 0
+      if (this.errors.q) count += 1
+      if (this.errors.a) count += 1
+  		this.inputMode = { q: false, a: false },
+  		this.focused = { q: false, a: false },
+  		this.errors = { q: false, a: false },
+  		this.inputs = { q: '', a: '' },
+      this.$emit('remove', count)
+    }
   }
 }
 </script>

--- a/src/components/CollectionEdit__Card.vue
+++ b/src/components/CollectionEdit__Card.vue
@@ -53,6 +53,36 @@ export default {
 			this.inputs = this.received
       this.$nextTick(() => this.$refs[qa][0].focus())
 		},
+    focus (qa) {
+			this.focused[qa] = true
+      this.$emit('focusCard')
+    },
+    blur (qa) {
+			if (this.inputs[qa] === '') {
+        if (!this.errors[qa]) {
+  	      this.errors[qa] = true
+  				this.$emit('addError')
+        }
+			} else {
+				if (this.errors[qa]) {
+					this.errors[qa] = false
+					this.$emit('removeError')
+				}
+				const body = this.inputs[qa]
+				this.$emit('change', { index: this.index, qa, body })
+				this.inputMode[qa] = false
+			}
+      this.focused[qa] = false
+      this.$emit('blurCard')
+    },
+    focusNext (qa) {
+      this.blur(qa)
+      if (qa === 'a') {
+        this.$emit('focusNext', this.index)
+      } else if (qa === 'q'){
+        this.$nextTick(() => this.input('a'))
+      }
+    },
     inputClass (qa) {
       const err = this.errors[qa]
       const focused = this.focused[qa]

--- a/src/components/CollectionEdit__Title.vue
+++ b/src/components/CollectionEdit__Title.vue
@@ -1,0 +1,79 @@
+<template>
+<div>
+  <input
+	  v-if="inputMode"
+    v-model.trim="inputValue"
+		ref="title"
+    type="text" placeholder="Collection name"
+    :class="titleClass"
+    :autofocus="createMode"
+    @focus="focusTitle"
+    @blur="blurTitle"
+    @keyup.enter="focusNext"
+  >
+	<p
+		v-else
+		@click="inputTitle"
+	>{{ displayedTitle }}</p>
+</div>
+</template>
+
+<script>
+export default {
+  props: ['title', 'createMode'],
+  data: () => ({
+		titleError: false,
+		inputMode: false,
+		inputValue: '',
+    focusedTitle: false,
+  }),
+  computed: {
+		displayedTitle () {
+			return this.inputValue ? this.inputValue : this.title
+		},
+    titleClass () {
+      return { error:  this.titleError && !this.focusedTitle }
+    }
+  },
+  methods: {
+		inputTitle () {
+			this.inputMode = true
+			this.inputValue = this.title
+      this.$nextTick(() => {
+				this.$refs.title.focus()
+				this.focusTitle()
+			})
+		},
+    focusTitle () {
+      this.focusedTitle = true
+    },
+    blurTitle () {
+			if (this.inputValue === '') {
+				if (!this.titleError) {
+					this.titleError = true
+					this.$emit('addError')
+				}
+			} else {
+				if (this.titleError) {
+					this.titleError = false
+					this.$emit('removeError')
+				}
+				this.$emit('changeTitle', this.inputValue)
+				this.inputMode = false
+			}
+      this.focusedTitle = false
+		},
+    focusNext (index) {
+			this.blurTitle()
+			this.$emit('focusNext', -1)
+    },
+	  fork(){
+	    this.$store.dispatch('fork', this.collection)
+	    this.$router.push(this.homeRoute)
+	  }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/CollectionEdit__Title.vue
+++ b/src/components/CollectionEdit__Title.vue
@@ -70,10 +70,6 @@ export default {
 			this.blurTitle()
 			this.$emit('focusNext', -1)
     },
-	  fork(){
-	    this.$store.dispatch('fork', this.collection)
-	    this.$router.push(this.homeRoute)
-	  }
   }
 }
 </script>

--- a/src/components/CollectionEdit__Title.vue
+++ b/src/components/CollectionEdit__Title.vue
@@ -13,6 +13,7 @@
   >
 	<p
 		v-else
+		class="ellipsis editable"
 		@click="inputTitle"
 	>{{ displayedTitle }}</p>
 </div>

--- a/src/components/CollectionEdit__Title.vue
+++ b/src/components/CollectionEdit__Title.vue
@@ -27,6 +27,9 @@ export default {
 		inputValue: '',
     focusedTitle: false,
   }),
+  created () {
+		if (this.createMode) this.inputTitle()
+  },
   computed: {
 		displayedTitle () {
 			return this.inputValue ? this.inputValue : this.title

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -115,7 +115,7 @@ export default new Vuex.Store({
       const collection = {
         collectionName: '',
         id,
-        items: [{ q: '', a: '' }]
+        items: [],
       }
       commit('deleteCollection', id)
       commit('pushCollection', collection)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -108,8 +108,11 @@ export default new Vuex.Store({
       commit('deleteCollection', id)
       commit('saveLocally')
     },
-    saveState ({ commit }) {
-      commit('saveLocally')
+    updateCollection ({ commit }, toSend) {
+      // TODO: should be modified to receive `toSend` and save
+      // accordingly to the data from this object
+      commit('saveLocally') // save locally
+      // save to DB
     },
     createCollection ({ commit }, id) {
       const collection = {


### PR DESCRIPTION
There are two new children in collectionEdit component:  collectionName and every card. 

Everything is displayed as text, on click it turns to input field. Some CSS styling should be improved later.

Before user clicks "save" there is an object `toSend` which contains all the modified, added and deleted cards.

Actual local saving is broken for now. But it's ready to be sent via http request to API

closes #67 