### PR TITLE
 feat: Add Notifications under Header. solves#94

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -93,9 +93,4 @@ form input{
 .btn-save:active {
   background-color:  #1a69a4;
 }
-
-.loginError{
-  margin-bottom: 10px;
-  color:#ff4d4d;
-}
 </style>

--- a/src/components/Homepage.vue
+++ b/src/components/Homepage.vue
@@ -1,7 +1,10 @@
 <template>
 <div class="homepage">
   <app-header/>
-  <router-view/>
+  <div>
+    <app-notifications/>
+    <router-view/>
+  </div>
   <app-footer/>
 </div>
 </template>
@@ -9,12 +12,14 @@
 <script>
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import Notifications from '@/components/Notifications'
 
 export default {
   name: 'Homepage',
   components: {
     'appHeader': Header,
     'appFooter': Footer,
+    'appNotifications': Notifications,
   },
   beforeCreate () {
     this.$store.dispatch('fetchLocalCollections')

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -1,0 +1,60 @@
+<template>
+<div class="notifications-container">
+  <div
+    class="notif"
+    :class="notificationClass(item)"
+    v-for="(item, index) in notifications" :key="index"
+    @click="dismiss(item.iat)"
+  >
+    {{ item.msg }}
+  </div>
+</div>
+</template>
+
+<script>
+export default {
+  name: 'Notifications',
+  computed: {
+    notifications() {
+      return this.$store.state.notifications.reverse()
+    },
+  },
+  methods: {
+    notificationClass(item, index) {
+      return {
+        'notif-succ': item.type == 'succ',
+        'notif-err': item.type == 'err',
+      }
+    },
+    dismiss(iat) {
+      this.$store.commit('dismissNotification', { iat })
+    }
+  },
+}
+</script>
+
+<style scoped>
+.notifications-container {
+  width: 100%;
+  padding: 1rem;
+  position: absolute;
+}
+.notif {
+  position: relative;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border-radius: .25rem;
+  border: 1px solid transparent;
+}
+.notif-err {
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+.notif-succ {
+  background-color: #d4edda;
+  border-color: #c3e6cb;
+}
+.hidden {
+  display: none;
+}
+</style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -101,7 +101,7 @@ export default new Vuex.Store({
         })
         .catch(err => {
           commit('setLoadingMode', false)
-          console.log(err.response ? err.response.statusText : err.message )
+          console.error(err.response ? err.response.statusText : err.message )
         })
     },
     deleteCollection ({ commit }, id) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,6 +11,7 @@ export default new Vuex.Store({
     publicCollections: [],
     counter: 1,
     loadingMode: false,
+    notifications: [],
   },
   getters: {
     collection: state => id => {
@@ -71,6 +72,13 @@ export default new Vuex.Store({
     },
     pushCollection(state, collection){
       state.collections.push(collection)
+    },
+    /* ***     notifications     ***  */
+    dismissNotification(state, { iat, delay }) {
+      const delayMs = delay*1000 || 0
+      setTimeout(() => {
+        state.notifications = state.notifications.filter(x => x.iat !== iat)
+      }, delayMs)
     },
   },
   actions: {
@@ -136,6 +144,17 @@ export default new Vuex.Store({
       commit('pushCollection', collectionCopy)
       commit('saveNewCollection', collectionCopy.id)
       commit('saveLocally')
-    }
+    },
+    /* ***     notifications     ***  */
+    pushNotification({ commit, state }, { type, msg }) {
+      let iat = Date.now()
+      const notificationsLength = state.notifications.length
+      if (notificationsLength) {
+        const lastIssuedAt = state.notifications[notificationsLength - 1].iat
+        while (iat <= lastIssuedAt) iat++
+      }
+      state.notifications.push({ type, msg, iat })
+      commit('dismissNotification', { iat, delay: 5 })
+    },
   }
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -156,5 +156,11 @@ export default new Vuex.Store({
       state.notifications.push({ type, msg, iat })
       commit('dismissNotification', { iat, delay: 5 })
     },
+    pushNotificationSucc({ dispatch, commit }, msg) {
+      dispatch('pushNotification', { msg, type: 'succ' })
+    },
+    pushNotificationErr({ dispatch, commit }, msg) {
+      dispatch('pushNotification', { msg, type: 'err' })
+    }
   }
 })


### PR DESCRIPTION

for success message:
`this.$store.dispatch('pushNotificationSucc', 'You have logged in!' )`
for error message: `this.$store.dispatch('pushNotificationErr', 'Your JWT expired!' )`
